### PR TITLE
Tentatively migrate to GHC 9.2

### DIFF
--- a/Data/Vector/Unboxed/Deriving.hs
+++ b/Data/Vector/Unboxed/Deriving.hs
@@ -56,9 +56,15 @@ common name = do
     let vName = mkName ("V_" ++ name)
     i <- newPatExp "idx"
     n <- newPatExp "len"
+#if MIN_VERSION_template_haskell(2,18,0)
+    mv  <- first (ConP mvName [] . (:[])) <$> newPatExp "mvec"
+    mv' <- first (ConP mvName [] . (:[])) <$> newPatExp "mvec'"
+    v   <- first (ConP vName  [] . (:[])) <$> newPatExp "vec"
+#else
     mv  <- first (ConP mvName . (:[])) <$> newPatExp "mvec"
     mv' <- first (ConP mvName . (:[])) <$> newPatExp "mvec'"
     v   <- first (ConP vName  . (:[])) <$> newPatExp "vec"
+#endif
     return Common {..}
 
 -- Turn any 'Name' into a capturable one.

--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,16 @@
+-- TODO: Remove this file when the migration is complete
+
+packages: .
+
+-- TODO: Remove the below vendored packages when they have migrated to GHC 9.2
+
+source-repository-package
+  type: git
+  location: https://github.com/haskell/primitive
+  tag: 1704f59d91ef964f83c120af4974251d50c2eb68
+
+source-repository-package
+  type: git
+  location: https://github.com/awjchen/vector
+  tag: fb6f584abff163a361563a98a7760c563f7a6832
+  subdir: vector

--- a/vector-th-unbox.cabal
+++ b/vector-th-unbox.cabal
@@ -20,6 +20,7 @@ tested-with:
   GHC == 7.4.2, GHC == 7.6.3, GHC == 7.8.4, GHC == 7.10.3,
   GHC == 8.0.2, GHC == 8.2.2, GHC == 8.4.4, GHC == 8.6.5, GHC == 8.8.4, GHC == 8.10.4,
   GHC == 9.0.1
+  -- TODO: add GHC == 9.2.?
 extra-source-files:
   CHANGELOG.md
   README.md
@@ -34,9 +35,9 @@ library
         Data.Vector.Unboxed.Deriving
 
     build-depends:
-        base >= 4.5 && < 4.16,
-        template-haskell >= 2.5 && <2.18,
-        vector >= 0.7.1 && <0.13
+        base >= 4.5 && < 4.17,
+        template-haskell >= 2.5 && <2.19,
+        vector >= 0.7.1 && <0.14
 
 test-suite sanity
     default-language: Haskell2010


### PR DESCRIPTION
This commit allows `vector-th-unbox` to build and run on GHC 9.2.0.20210422, including tests.

This commit is not intended to be merged into main. It includes a lot of "extras" that I needed to get it to run. It is only intended to help with migration at a later date, when the final versions of GHC 9.2 and this library's dependencies become available. At that time, I hope someone can save some time by taking the "good parts" of this commit.

Changes:

- Update the `ConP` constructor for `template-haskell-2.18.*` as in   https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#template-haskell-218