### PR TITLE
Allow building with `vector-0.13.*`

### DIFF
--- a/vector-th-unbox.cabal
+++ b/vector-th-unbox.cabal
@@ -37,7 +37,7 @@ library
     build-depends:
         base >= 4.9 && < 4.17,
         template-haskell >= 2.5 && <2.19,
-        vector >= 0.7.1 && <0.13
+        vector >= 0.7.1 && <0.14
 
 test-suite sanity
     default-language: Haskell2010


### PR DESCRIPTION
Fixes #8.