### PR TITLE
Bump base and template-haskell for GHC 9.6

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,38 +1,51 @@
 name: Haskell CI
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:
 
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2.1']
+        ghc: ['8.0', '8.2', '8.4', '8.6', '8.8', '8.10', '9.0', '9.2', '9.4', '9.6']
+
     steps:
-    - uses: actions/checkout@v2
-    - uses: haskell/actions/setup@v1
+    - uses: actions/checkout@v3
+
+    - uses: haskell/actions/setup@v2
       with:
         ghc-version: ${{ matrix.ghc }}
-        cabal-version: '3.0'
+        cabal-version: latest
 
-    - name: cabal Cache
-      uses: actions/cache@v1
-      env:
-        cache-name: cache-cabal
+    - name: Determine precise GHC and Cabal versions
+      run: |
+        echo "GHC_VERSION=$(ghc --numeric-version)"     >> "${GITHUB_ENV}"
+        echo "CABAL_VERSION=$(cabal --numeric-version)" >> "${GITHUB_ENV}"
+
+    - name: Cache dependencies
+      uses: actions/cache@v3
       with:
         path: ~/.cabal
-        key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/*.cabal') }}-${{ hashFiles('**/cabal.project') }}
+        key: ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-sha-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-build-${{ env.cache-name }}-
-          ${{ runner.os }}-build-
-          ${{ runner.os }}-
+          ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-
+          ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-
 
     - name: Install dependencies
       run: |
         cabal update
         cabal build --only-dependencies --enable-tests --enable-benchmarks
+
     - name: Build
       run: cabal build --enable-tests --enable-benchmarks all
+
     - name: Run tests
       run: cabal test all

--- a/vector-th-unbox.cabal
+++ b/vector-th-unbox.cabal
@@ -35,8 +35,8 @@ library
         Data.Vector.Unboxed.Deriving
 
     build-depends:
-        base >= 4.9 && < 4.18,
-        template-haskell >= 2.5 && <2.20,
+        base >= 4.9 && < 4.19,
+        template-haskell >= 2.5 && <2.21,
         vector >= 0.7.1 && <0.14
 
 test-suite sanity


### PR DESCRIPTION
Extend CI to 9.4 and 9.6; better cache keys, bump actions.

Workflow run at: https://github.com/andreasabel/vector-th-unbox/actions/runs/4442558688
Revision 4 published at: https://hackage.haskell.org/package/vector-th-unbox-0.2.2/revisions/

Fixes #11 
- #11