### PR TITLE
CI: use new features of haskell-actions/setup, separate cache restore/save

### DIFF
--- a/.github/workflows/haskell.yml
+++ b/.github/workflows/haskell.yml
@@ -1,4 +1,4 @@
-name: Haskell CI
+name: Cabal CI
 
 on:
   push:
@@ -21,31 +21,36 @@ jobs:
     - uses: actions/checkout@v4
 
     - uses: haskell-actions/setup@v2
+      id: setup
       with:
         ghc-version: ${{ matrix.ghc }}
         cabal-version: latest
+        cabal-update: true
 
-    - name: Determine precise GHC and Cabal versions
-      run: |
-        echo "GHC_VERSION=$(ghc --numeric-version)"     >> "${GITHUB_ENV}"
-        echo "CABAL_VERSION=$(cabal --numeric-version)" >> "${GITHUB_ENV}"
-
-    - name: Cache dependencies
-      uses: actions/cache@v3
+    - name: Restore cached dependencies
+      uses: actions/cache/restore@v4
+      id: cache
+      env:
+        key: ${{ runner.os }}-ghc-${{ steps.setup.outputs.ghc-version }}
       with:
-        path: ~/.cabal
-        key: ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-sha-${{ github.sha }}
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key: ${{ env.key }}-cabal-${{ steps.setup.outputs.cabal-version }}-sha-${{ github.sha }}
         restore-keys: |
-          ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-cabal-${{ env.CABAL_VERSION }}-
-          ${{ runner.os }}-ghc-${{ env.GHC_VERSION }}-
+          ${{ env.key }}-cabal-${{ steps.setup.outputs.cabal-version }}-
+          ${{ env.key }}-
 
     - name: Install dependencies
-      run: |
-        cabal update
-        cabal build --only-dependencies --enable-tests --enable-benchmarks
+      run: cabal build --only-dependencies --enable-tests --enable-benchmarks
 
     - name: Build
-      run: cabal build --enable-tests --enable-benchmarks all
+      run: cabal build --enable-tests --enable-benchmarks
 
     - name: Run tests
-      run: cabal test all
+      run: cabal test
+
+    - name: Cache dependencies
+      uses: actions/cache/save@v4
+      if: always() && steps.cache.outputs.cache-hit != 'true'
+      with:
+        path: ${{ steps.setup.outputs.cabal-store }}
+        key:  ${{ steps.cache.outputs.cache-primary-key }}


### PR DESCRIPTION
This is a slight modernisation of the CI:
- use outputs of haskell-actions/setup
- use separation of actions/cache into restore and save step